### PR TITLE
[Android] Downgrade AGP to last stable

### DIFF
--- a/android/mobile/gradle/libs.versions.toml
+++ b/android/mobile/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.0-rc02"
+agp = "8.3.2"
 kotlin = "1.9.23"
 coreKtx = "1.13.0"
 lifecycleRuntimeKtx = "2.7.0"

--- a/android/tv-custom/gradle/libs.versions.toml
+++ b/android/tv-custom/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.0-rc02"
+agp = "8.3.2"
 kotlin = "1.9.23"
 coreKtx = "1.13.0"
 lifecycleRuntimeKtx = "2.7.0"

--- a/android/tv-device-auth-grant/gradle/libs.versions.toml
+++ b/android/tv-device-auth-grant/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.0-rc02"
+agp = "8.3.2"
 kotlin = "1.9.23"
 coreKtx = "1.13.0"
 lifecycleRuntimeKtx = "2.7.0"


### PR DESCRIPTION
Renovate upgraded this to a version that is too new, and not compatible with various other dependencies.