### PR TITLE
Add iOS sample

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,29 @@
+name: Test iOS Pull Requests
+
+on:
+  pull_request:
+    paths:
+      - 'ios/**'
+
+  push:
+    branches: [ main ]
+    paths:
+      - 'ios/**'
+
+  # This allows us to manually run this job
+  workflow_dispatch:
+
+jobs:
+
+  swift-code-checks:
+    name: Code Tests
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 15.3
+        run: sudo xcode-select -s /Applications/Xcode_15.3.app
+
+      - name: Build with xcodebuild
+        run: xcodebuild -project ios/mobile/OpenPass-Sample-iOS.xcodeproj -scheme OpenPass-Sample-iOS build 

--- a/ios/mobile/.gitignore
+++ b/ios/mobile/.gitignore
@@ -1,0 +1,51 @@
+# https://github.com/github/gitignore/blob/main/Swift.gitignore
+
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/

--- a/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.pbxproj
+++ b/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.pbxproj
@@ -1,0 +1,386 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BF9F15E42BE11BFE00F1723A /* OpenPassSampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9F15E32BE11BFE00F1723A /* OpenPassSampleApp.swift */; };
+		BF9F15E62BE11BFE00F1723A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9F15E52BE11BFE00F1723A /* ContentView.swift */; };
+		BF9F15E82BE11BFF00F1723A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF9F15E72BE11BFF00F1723A /* Assets.xcassets */; };
+		BF9F15EB2BE11BFF00F1723A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF9F15EA2BE11BFF00F1723A /* Preview Assets.xcassets */; };
+		BF9F15F32BE11C3B00F1723A /* OpenPass in Frameworks */ = {isa = PBXBuildFile; productRef = BF9F15F22BE11C3B00F1723A /* OpenPass */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		BF9F15E02BE11BFE00F1723A /* OpenPass-Sample-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OpenPass-Sample-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF9F15E32BE11BFE00F1723A /* OpenPassSampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPassSampleApp.swift; sourceTree = "<group>"; };
+		BF9F15E52BE11BFE00F1723A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BF9F15E72BE11BFF00F1723A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		BF9F15EA2BE11BFF00F1723A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		BF9F15F42BE152BF00F1723A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BF9F15DD2BE11BFE00F1723A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF9F15F32BE11C3B00F1723A /* OpenPass in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BF9F15D72BE11BFE00F1723A = {
+			isa = PBXGroup;
+			children = (
+				BF9F15E22BE11BFE00F1723A /* OpenPass-Sample-iOS */,
+				BF9F15E12BE11BFE00F1723A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		BF9F15E12BE11BFE00F1723A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BF9F15E02BE11BFE00F1723A /* OpenPass-Sample-iOS.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BF9F15E22BE11BFE00F1723A /* OpenPass-Sample-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				BF9F15F42BE152BF00F1723A /* Info.plist */,
+				BF9F15E32BE11BFE00F1723A /* OpenPassSampleApp.swift */,
+				BF9F15E52BE11BFE00F1723A /* ContentView.swift */,
+				BF9F15E72BE11BFF00F1723A /* Assets.xcassets */,
+				BF9F15E92BE11BFF00F1723A /* Preview Content */,
+			);
+			path = "OpenPass-Sample-iOS";
+			sourceTree = "<group>";
+		};
+		BF9F15E92BE11BFF00F1723A /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				BF9F15EA2BE11BFF00F1723A /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		BF9F15DF2BE11BFE00F1723A /* OpenPass-Sample-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BF9F15EE2BE11BFF00F1723A /* Build configuration list for PBXNativeTarget "OpenPass-Sample-iOS" */;
+			buildPhases = (
+				BF9F15DC2BE11BFE00F1723A /* Sources */,
+				BF9F15DD2BE11BFE00F1723A /* Frameworks */,
+				BF9F15DE2BE11BFE00F1723A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "OpenPass-Sample-iOS";
+			packageProductDependencies = (
+				BF9F15F22BE11C3B00F1723A /* OpenPass */,
+			);
+			productName = "OpenPass-Sample-iOS";
+			productReference = BF9F15E02BE11BFE00F1723A /* OpenPass-Sample-iOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BF9F15D82BE11BFE00F1723A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1530;
+				LastUpgradeCheck = 1530;
+				TargetAttributes = {
+					BF9F15DF2BE11BFE00F1723A = {
+						CreatedOnToolsVersion = 15.3;
+					};
+				};
+			};
+			buildConfigurationList = BF9F15DB2BE11BFE00F1723A /* Build configuration list for PBXProject "OpenPass-Sample-iOS" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = BF9F15D72BE11BFE00F1723A;
+			packageReferences = (
+				BF9F15F12BE11C3B00F1723A /* XCRemoteSwiftPackageReference "openpass-ios-sdk" */,
+			);
+			productRefGroup = BF9F15E12BE11BFE00F1723A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BF9F15DF2BE11BFE00F1723A /* OpenPass-Sample-iOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		BF9F15DE2BE11BFE00F1723A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF9F15EB2BE11BFF00F1723A /* Preview Assets.xcassets in Resources */,
+				BF9F15E82BE11BFF00F1723A /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BF9F15DC2BE11BFE00F1723A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF9F15E62BE11BFE00F1723A /* ContentView.swift in Sources */,
+				BF9F15E42BE11BFE00F1723A /* OpenPassSampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BF9F15EC2BE11BFF00F1723A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.7;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		BF9F15ED2BE11BFF00F1723A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.7;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		BF9F15EF2BE11BFF00F1723A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"OpenPass-Sample-iOS/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$SRCROOT/OpenPass-Sample-iOS/Info.plist";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.7;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.openpass.sso.OpenPass-Sample-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BF9F15F02BE11BFF00F1723A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"OpenPass-Sample-iOS/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$SRCROOT/OpenPass-Sample-iOS/Info.plist";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.7;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.openpass.sso.OpenPass-Sample-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BF9F15DB2BE11BFE00F1723A /* Build configuration list for PBXProject "OpenPass-Sample-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF9F15EC2BE11BFF00F1723A /* Debug */,
+				BF9F15ED2BE11BFF00F1723A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BF9F15EE2BE11BFF00F1723A /* Build configuration list for PBXNativeTarget "OpenPass-Sample-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF9F15EF2BE11BFF00F1723A /* Debug */,
+				BF9F15F02BE11BFF00F1723A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BF9F15F12BE11C3B00F1723A /* XCRemoteSwiftPackageReference "openpass-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/openpass-sso/openpass-ios-sdk";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BF9F15F22BE11C3B00F1723A /* OpenPass */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BF9F15F12BE11C3B00F1723A /* XCRemoteSwiftPackageReference "openpass-ios-sdk" */;
+			productName = OpenPass;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = BF9F15D82BE11BFE00F1723A /* Project object */;
+}

--- a/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "5ec664ce708ea230b41325ace93bc6082dbae674b37961a80a1649d297f0645d",
+  "pins" : [
+    {
+      "identity" : "openpass-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openpass-sso/openpass-ios-sdk",
+      "state" : {
+        "branch" : "main",
+        "revision" : "381fecf5e851e2680954c6a33c5934cac54e5b92"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/mobile/OpenPass-Sample-iOS.xcodeproj/xcshareddata/xcschemes/OpenPass-Sample-iOS.xcscheme
+++ b/ios/mobile/OpenPass-Sample-iOS.xcodeproj/xcshareddata/xcschemes/OpenPass-Sample-iOS.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF9F15DF2BE11BFE00F1723A"
+               BuildableName = "OpenPass-Sample-iOS.app"
+               BlueprintName = "OpenPass-Sample-iOS"
+               ReferencedContainer = "container:OpenPass-Sample-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BF9F15DF2BE11BFE00F1723A"
+            BuildableName = "OpenPass-Sample-iOS.app"
+            BlueprintName = "OpenPass-Sample-iOS"
+            ReferencedContainer = "container:OpenPass-Sample-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BF9F15DF2BE11BFE00F1723A"
+            BuildableName = "OpenPass-Sample-iOS.app"
+            BlueprintName = "OpenPass-Sample-iOS"
+            ReferencedContainer = "container:OpenPass-Sample-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/mobile/OpenPass-Sample-iOS/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/mobile/OpenPass-Sample-iOS/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/mobile/OpenPass-Sample-iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/mobile/OpenPass-Sample-iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/mobile/OpenPass-Sample-iOS/Assets.xcassets/Contents.json
+++ b/ios/mobile/OpenPass-Sample-iOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/mobile/OpenPass-Sample-iOS/ContentView.swift
+++ b/ios/mobile/OpenPass-Sample-iOS/ContentView.swift
@@ -1,0 +1,104 @@
+import OpenPass
+import SwiftUI
+
+@MainActor
+final class Model: ObservableObject {
+    @Published
+    private(set) var state = ViewState.loading
+
+    private let openPassManager = OpenPassManager.shared
+
+    private var signInTask: Task<Void, Never>?
+
+    init() {
+        updateTokenState()
+    }
+
+    private func updateTokenState() {
+        let tokens = openPassManager.openPassTokens
+        if let email = tokens?.idToken?.email {
+            state = .signedIn(email: email)
+        } else {
+            state = .signedOut
+        }
+    }
+
+    func signIn() {
+        signInTask?.cancel()
+        signInTask = Task<Void, Never> {
+            do {
+                _ = try await openPassManager.beginSignInUXFlow()
+                updateTokenState()
+            } catch {
+                state = .error(error)
+            }
+        }
+    }
+
+    func signOut() {
+        _ = openPassManager.signOut()
+        updateTokenState()
+    }
+}
+
+extension Model {
+    enum ViewState {
+        case loading
+        case signedIn(email: String)
+        case signedOut
+        case error(Error)
+    }
+}
+
+struct ContentView: View {
+
+    @ObservedObject
+    private var model = Model()
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Welcome")
+                .font(.largeTitle)
+            Text("What would you like to do?")
+
+            Spacer()
+                .frame(height: 16)
+
+            switch model.state {
+            case .loading:
+                ProgressView()
+            case .signedIn(email: let email):
+                Button("Sign Out") {
+                    model.signOut()
+                }
+                Text("Signed In: \(email)")
+            case .signedOut:
+                Button("Sign In") {
+                    model.signIn()
+                }
+                Text("Signed Out")
+            case .error(let error):
+                Button("Sign In") {
+                    model.signIn()
+                }
+                Text("Error: \(error.localizedDescription)")
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}
+
+extension OpenPassError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .authorizationCancelled:
+            return "User cancelled"
+        default:
+            return String(describing: self)
+        }
+    }
+}

--- a/ios/mobile/OpenPass-Sample-iOS/Info.plist
+++ b/ios/mobile/OpenPass-Sample-iOS/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>OpenPassClientId</key>
+	<string>9ede0d6122ed40c0ab0207720974ca12</string>
+	<key>OpenPassRedirectHost</key>
+	<string>com.myopenpass.sample</string>
+</dict>
+</plist>

--- a/ios/mobile/OpenPass-Sample-iOS/OpenPassSampleApp.swift
+++ b/ios/mobile/OpenPass-Sample-iOS/OpenPassSampleApp.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+@main
+struct OpenPassSampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .buttonStyle(.signIn)
+        }
+    }
+}
+
+private struct SignInButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(width: 240, height: 40)
+            .background(Color.accentColor)
+            .foregroundColor(.white)
+            .cornerRadius(20)
+            .clipped()
+    }
+}
+extension ButtonStyle where Self == SignInButtonStyle {
+    static var signIn: SignInButtonStyle {
+        SignInButtonStyle()
+    }
+}

--- a/ios/mobile/OpenPass-Sample-iOS/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/ios/mobile/OpenPass-Sample-iOS/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
Adds a simple iOS SwiftUI app from the Xcode new project template to demonstrate sign in flow.  Also adds a CI job to ensure it compiles.

The UI has been implemented to match the Android mobile sample.