### PR TITLE
Add tvOS sample

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Select Xcode 15.3
         run: sudo xcode-select -s /Applications/Xcode_15.3.app
 
-      - name: Build with xcodebuild
+      - name: Build mobile sample with xcodebuild
         run: xcodebuild -project ios/mobile/OpenPass-Sample-iOS.xcodeproj -scheme OpenPass-Sample-iOS build 
+
+      - name: Build tv sample with xcodebuild
+        run: xcodebuild -project ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj -scheme OpenPass-Sample-tvOS build

--- a/ios/tv-device-auth-grant/.gitignore
+++ b/ios/tv-device-auth-grant/.gitignore
@@ -1,0 +1,51 @@
+# https://github.com/github/gitignore/blob/main/Swift.gitignore
+
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.pbxproj
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.pbxproj
@@ -1,0 +1,378 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BF395E942BE5434400725F94 /* UIImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF395E932BE5434400725F94 /* UIImageExtensions.swift */; };
+		BF9F16022BE19E0600F1723A /* OpenPassSampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9F16012BE19E0600F1723A /* OpenPassSampleApp.swift */; };
+		BF9F16042BE19E0600F1723A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9F16032BE19E0600F1723A /* ContentView.swift */; };
+		BF9F16062BE19E0700F1723A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF9F16052BE19E0700F1723A /* Assets.xcassets */; };
+		BF9F16092BE19E0700F1723A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF9F16082BE19E0700F1723A /* Preview Assets.xcassets */; };
+		BF9F16112BE2490D00F1723A /* OpenPass in Frameworks */ = {isa = PBXBuildFile; productRef = BF9F16102BE2490D00F1723A /* OpenPass */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		BF395E932BE5434400725F94 /* UIImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtensions.swift; sourceTree = "<group>"; };
+		BF9F15FE2BE19E0600F1723A /* OpenPass-Sample-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OpenPass-Sample-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF9F16012BE19E0600F1723A /* OpenPassSampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPassSampleApp.swift; sourceTree = "<group>"; };
+		BF9F16032BE19E0600F1723A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BF9F16052BE19E0700F1723A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		BF9F16082BE19E0700F1723A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		BF9F16122BE24C5400F1723A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BF9F15FB2BE19E0600F1723A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF9F16112BE2490D00F1723A /* OpenPass in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BF9F15F52BE19E0600F1723A = {
+			isa = PBXGroup;
+			children = (
+				BF9F16002BE19E0600F1723A /* OpenPass-Sample-tvOS */,
+				BF9F15FF2BE19E0600F1723A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		BF9F15FF2BE19E0600F1723A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BF9F15FE2BE19E0600F1723A /* OpenPass-Sample-tvOS.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BF9F16002BE19E0600F1723A /* OpenPass-Sample-tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				BF9F16122BE24C5400F1723A /* Info.plist */,
+				BF9F16032BE19E0600F1723A /* ContentView.swift */,
+				BF9F16012BE19E0600F1723A /* OpenPassSampleApp.swift */,
+				BF395E932BE5434400725F94 /* UIImageExtensions.swift */,
+				BF9F16052BE19E0700F1723A /* Assets.xcassets */,
+				BF9F16072BE19E0700F1723A /* Preview Content */,
+			);
+			path = "OpenPass-Sample-tvOS";
+			sourceTree = "<group>";
+		};
+		BF9F16072BE19E0700F1723A /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				BF9F16082BE19E0700F1723A /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		BF9F15FD2BE19E0600F1723A /* OpenPass-Sample-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BF9F160C2BE19E0700F1723A /* Build configuration list for PBXNativeTarget "OpenPass-Sample-tvOS" */;
+			buildPhases = (
+				BF9F15FA2BE19E0600F1723A /* Sources */,
+				BF9F15FB2BE19E0600F1723A /* Frameworks */,
+				BF9F15FC2BE19E0600F1723A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "OpenPass-Sample-tvOS";
+			packageProductDependencies = (
+				BF9F16102BE2490D00F1723A /* OpenPass */,
+			);
+			productName = "OpenPass-Sample-tvOS";
+			productReference = BF9F15FE2BE19E0600F1723A /* OpenPass-Sample-tvOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BF9F15F62BE19E0600F1723A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1530;
+				LastUpgradeCheck = 1530;
+				TargetAttributes = {
+					BF9F15FD2BE19E0600F1723A = {
+						CreatedOnToolsVersion = 15.3;
+					};
+				};
+			};
+			buildConfigurationList = BF9F15F92BE19E0600F1723A /* Build configuration list for PBXProject "OpenPass-Sample-tvOS" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = BF9F15F52BE19E0600F1723A;
+			packageReferences = (
+				BF9F160F2BE2490D00F1723A /* XCRemoteSwiftPackageReference "openpass-ios-sdk" */,
+			);
+			productRefGroup = BF9F15FF2BE19E0600F1723A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BF9F15FD2BE19E0600F1723A /* OpenPass-Sample-tvOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		BF9F15FC2BE19E0600F1723A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF9F16092BE19E0700F1723A /* Preview Assets.xcassets in Resources */,
+				BF9F16062BE19E0700F1723A /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BF9F15FA2BE19E0600F1723A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF395E942BE5434400725F94 /* UIImageExtensions.swift in Sources */,
+				BF9F16042BE19E0600F1723A /* ContentView.swift in Sources */,
+				BF9F16022BE19E0600F1723A /* OpenPassSampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BF9F160A2BE19E0700F1723A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = appletvos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TVOS_DEPLOYMENT_TARGET = 17.4;
+			};
+			name = Debug;
+		};
+		BF9F160B2BE19E0700F1723A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = appletvos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				TVOS_DEPLOYMENT_TARGET = 17.4;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		BF9F160D2BE19E0700F1723A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"OpenPass-Sample-tvOS/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$SRCROOT/OpenPass-Sample-tvOS/Info.plist";
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.openpass.sso.OpenPass-Sample-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
+		BF9F160E2BE19E0700F1723A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"OpenPass-Sample-tvOS/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$SRCROOT/OpenPass-Sample-tvOS/Info.plist";
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.openpass.sso.OpenPass-Sample-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BF9F15F92BE19E0600F1723A /* Build configuration list for PBXProject "OpenPass-Sample-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF9F160A2BE19E0700F1723A /* Debug */,
+				BF9F160B2BE19E0700F1723A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BF9F160C2BE19E0700F1723A /* Build configuration list for PBXNativeTarget "OpenPass-Sample-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF9F160D2BE19E0700F1723A /* Debug */,
+				BF9F160E2BE19E0700F1723A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BF9F160F2BE2490D00F1723A /* XCRemoteSwiftPackageReference "openpass-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/openpass-sso/openpass-ios-sdk";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BF9F16102BE2490D00F1723A /* OpenPass */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BF9F160F2BE2490D00F1723A /* XCRemoteSwiftPackageReference "openpass-ios-sdk" */;
+			productName = OpenPass;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = BF9F15F62BE19E0600F1723A /* Project object */;
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "5ec664ce708ea230b41325ace93bc6082dbae674b37961a80a1649d297f0645d",
+  "pins" : [
+    {
+      "identity" : "openpass-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openpass-sso/openpass-ios-sdk",
+      "state" : {
+        "branch" : "main",
+        "revision" : "aa6bb0c8a56df8040e6e9924d77f045b5ad99ec2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ]
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ]
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
@@ -1,0 +1,32 @@
+{
+  "assets" : [
+    {
+      "filename" : "App Icon - App Store.imagestack",
+      "idiom" : "tv",
+      "role" : "primary-app-icon",
+      "size" : "1280x768"
+    },
+    {
+      "filename" : "App Icon.imagestack",
+      "idiom" : "tv",
+      "role" : "primary-app-icon",
+      "size" : "400x240"
+    },
+    {
+      "filename" : "Top Shelf Image Wide.imageset",
+      "idiom" : "tv",
+      "role" : "top-shelf-image-wide",
+      "size" : "2320x720"
+    },
+    {
+      "filename" : "Top Shelf Image.imageset",
+      "idiom" : "tv",
+      "role" : "top-shelf-image",
+      "size" : "1920x720"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/ContentView.swift
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/ContentView.swift
@@ -1,0 +1,155 @@
+import CoreImage.CIFilterBuiltins
+import Foundation
+import OpenPass
+import SwiftUI
+
+@MainActor
+final class Model: ObservableObject {
+    @Published
+    private(set) var state = ViewState.loading {
+        didSet {
+            if case .deviceCodeAvailable(let deviceCode) = state {
+                verificationUriCompleteImage = deviceCode.verificationUriComplete.flatMap(UIImage.qrCode(url: ))
+            } else {
+                verificationUriCompleteImage = nil
+            }
+        }
+    }
+
+    /// A QR Code representation of `deviceCode.verificationUriComplete`, if available
+    @Published 
+    private(set) var verificationUriCompleteImage: UIImage?
+
+    private let openPassManager = OpenPassManager.shared
+
+    private var signInTask: Task<Void, Never>?
+
+    init() {
+        updateTokenState()
+    }
+
+    private func updateTokenState() {
+        let tokens = openPassManager.openPassTokens
+        if let email = tokens?.idToken?.email {
+            state = .signedIn(email: email)
+        } else {
+            state = .signedOut
+        }
+    }
+
+    func signIn() {
+        cancelSignIn()
+        state = .loading
+
+        signInTask = Task {
+            let flow = openPassManager.deviceAuthorizationFlow
+
+            do {
+                // Request a Device Code
+                let deviceCode = try await flow.fetchDeviceCode()
+                state = .deviceCodeAvailable(deviceCode)
+
+                // Poll for authorization
+                _ = try await flow.fetchAccessToken(deviceCode: deviceCode)
+                updateTokenState()
+            } catch {
+                state = .error(error)
+            }
+        }
+    }
+
+    func cancelSignIn() {
+        signInTask?.cancel()
+        signInTask = nil
+    }
+
+    func signOut() {
+        _ = openPassManager.signOut()
+        updateTokenState()
+    }
+}
+
+extension Model {
+    enum ViewState {
+        case loading
+        case deviceCodeAvailable(DeviceCode)
+        case signedIn(email: String)
+        case signedOut
+        case error(Error)
+    }
+}
+
+struct ContentView: View {
+
+    @ObservedObject
+    private var model = Model()
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 16) {
+            Text("Welcome")
+                .font(.largeTitle)
+            Text("What would you like to do?")
+
+            Spacer()
+                .frame(height: 32)
+
+            switch model.state {
+            case .signedIn:
+                Button("Sign Out") {
+                    model.signOut()
+                }
+            case .loading, .deviceCodeAvailable:
+                Button("Cancel") {
+                    model.cancelSignIn()
+                }
+            case .signedOut, .error:
+                Button("Sign In") {
+                    model.signIn()
+                }
+            }
+
+            Spacer()
+                .frame(height: 16)
+
+            switch model.state {
+            case .loading:
+                ProgressView()
+            case .deviceCodeAvailable(let deviceCode):
+                Text("Code: \(deviceCode.userCode)")
+                Text("URL: \(deviceCode.verificationUriComplete ?? deviceCode.verificationUri) ")
+
+                if let verificationUriCompleteImage = model.verificationUriCompleteImage {
+                    Image(uiImage: verificationUriCompleteImage)
+                        .resizable()
+                        .frame(width: 300, height: 300)
+                }
+            case .signedIn(email: let email):
+                Text("Signed In: \(email)")
+            case .signedOut:
+                Text("Signed Out")
+            case .error(let error):
+                Text("Error: \(error.localizedDescription)")
+            }
+
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}
+
+extension OpenPassError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .authorizationCancelled:
+            return "User cancelled"
+        case .tokenExpired:
+            return "Token expired. Please restart the Sign In flow"
+        default:
+            return String(describing: self)
+        }
+    }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Info.plist
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>OpenPassClientId</key>
+	<string>51c42041a7de48f59bff4f8a8a6ad18b</string>
+	<key>OpenPassRedirectHost</key>
+	<string>com.myopenpass.sample</string>
+</dict>
+</plist>

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/OpenPassSampleApp.swift
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/OpenPassSampleApp.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+@main
+struct OpenPassSampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .buttonStyle(.signIn)
+        }
+    }
+}
+
+private struct SignInButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(width: 240, height: 40)
+            .background(Color.accentColor)
+            .foregroundColor(.black)
+            .cornerRadius(20)
+            .clipped()
+    }
+}
+extension ButtonStyle where Self == SignInButtonStyle {
+    static var signIn: SignInButtonStyle {
+        SignInButtonStyle()
+    }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/UIImageExtensions.swift
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS/UIImageExtensions.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+extension UIImage {
+
+    /// Produces a QR code image representation of a url
+    static func qrCode(url: String) -> UIImage? {
+        guard let data = url.data(using: String.Encoding.ascii) else {
+            return nil
+        }
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = data
+        filter.correctionLevel = "M"
+
+        let transform = CGAffineTransform(scaleX: 10, y: 10)
+        guard let output = filter.outputImage?.transformed(by: transform) else {
+            return nil
+        }
+        // The filter's outputImage isn't suitable for rendering as-is. Convert to PNG and back.
+        return UIImage(ciImage: output)
+            .pngData()
+            .flatMap(UIImage.init(data: ))
+    }
+}


### PR DESCRIPTION
Adds a simple tvOS SwiftUI app from the Xcode new project template to demonstrate sign in flow. Also adds a CI job to ensure it compiles.

The UI has been implemented to match the Android mobile sample.