### PR TITLE
Upgrade iOS Sample OpenPass to 1.1.0

### DIFF
--- a/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.pbxproj
+++ b/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.pbxproj
@@ -368,8 +368,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/openpass-sso/openpass-ios-sdk";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/mobile/OpenPass-Sample-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openpass-sso/openpass-ios-sdk",
       "state" : {
-        "branch" : "main",
-        "revision" : "381fecf5e851e2680954c6a33c5934cac54e5b92"
+        "revision" : "1ea8748a7ccb9e004f39b458b9a3ac5d886e2f0f",
+        "version" : "1.1.0"
       }
     }
   ],


### PR DESCRIPTION
Upgrade OpenPass to 1.1.0 and allow upgrades to the next major version.