### PR TITLE
Upgrade iOS TV Sample OpenPass to 1.1.0

### DIFF
--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.pbxproj
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.pbxproj
@@ -360,8 +360,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/openpass-sso/openpass-ios-sdk";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/tv-device-auth-grant/OpenPass-Sample-tvOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openpass-sso/openpass-ios-sdk",
       "state" : {
-        "branch" : "main",
-        "revision" : "aa6bb0c8a56df8040e6e9924d77f045b5ad99ec2"
+        "revision" : "1ea8748a7ccb9e004f39b458b9a3ac5d886e2f0f",
+        "version" : "1.1.0"
       }
     }
   ],


### PR DESCRIPTION
Upgrade OpenPass to 1.1.0 and allow upgrades to the next major version.