### PR TITLE
[Android] Bump Compile/Target SDK (35)

### DIFF
--- a/android/mobile/app/build.gradle.kts
+++ b/android/mobile/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.ttd.sso.sample"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.ttd.sso.sample"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
     }
@@ -36,10 +36,6 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
-}
-
-composeCompiler {
-    enableStrongSkippingMode = true
 }
 
 dependencies {

--- a/android/tv-custom/app/build.gradle.kts
+++ b/android/tv-custom/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.ttd.sso.sample"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.ttd.sso.sample"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
     }
@@ -36,10 +36,6 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
-}
-
-composeCompiler {
-    enableStrongSkippingMode = true
 }
 
 dependencies {

--- a/android/tv-device-auth-grant/app/build.gradle.kts
+++ b/android/tv-device-auth-grant/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.ttd.sso.sample"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.ttd.sso.sample"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
     }
@@ -36,10 +36,6 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
-}
-
-composeCompiler {
-    enableStrongSkippingMode = true
 }
 
 dependencies {


### PR DESCRIPTION
This PR bumps the targetSdk and compileSdk to v35. This is blocking a number of Renovate MRs from landing, hence why i'm doing this manually. I also saw that `enableStrongSkippingMode` was still enabled, but this is now deprecated since it's the default due to the version of Kotlin we're using.