### PR TITLE
[Android] Bump OpenPass SDK (v2.8.2)

### DIFF
--- a/android/mobile/app/src/main/java/com/ttd/sso/sample/ui/AuthScreenViewModel.kt
+++ b/android/mobile/app/src/main/java/com/ttd/sso/sample/ui/AuthScreenViewModel.kt
@@ -61,6 +61,7 @@ class AuthScreenViewModel(
                 // Observe the results of the flow, handling them accordingly.
                 newClient.state.collect { state ->
                     when (state) {
+                        is WebSignInFlowState.Initialized -> Unit
                         is WebSignInFlowState.Error -> _viewState.emit(ErrorState(state.error))
                         is WebSignInFlowState.Complete -> {
                             val tokens = manager.currentTokens

--- a/android/mobile/gradle/libs.versions.toml
+++ b/android/mobile/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ coreKtx = "1.15.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.0"
 composeBom = "2025.01.01"
-openpass = "2.2.0"
+openpass = "2.8.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/android/tv-custom/gradle/libs.versions.toml
+++ b/android/tv-custom/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.0"
 composeBom = "2025.01.01"
 tvCompose = "1.0.0-alpha10"
-openpass = "2.2.0"
+openpass = "2.8.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/android/tv-device-auth-grant/gradle/libs.versions.toml
+++ b/android/tv-device-auth-grant/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.0"
 composeBom = "2025.01.01"
 tvCompose = "1.0.0-alpha10"
-openpass = "2.2.0"
+openpass = "2.8.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
This PR bumps the referenced OpenPass SDK on Android to the latest (v2.8.2). This required some additional code changes due to a slight change in the API, hence why I had to do this manually.