### PR TITLE
[Android] Bump TV Compose Dependencies

### DIFF
--- a/android/tv-custom/gradle/libs.versions.toml
+++ b/android/tv-custom/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ coreKtx = "1.15.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.0"
 composeBom = "2025.01.01"
-tvCompose = "1.0.0-alpha10"
 openpass = "2.8.2"
 
 [libraries]
@@ -18,8 +17,8 @@ androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-tv-foundation = { group = "androidx.tv", name = "tv-foundation", version.ref = "tvCompose" }
-androidx-tv-material = { group = "androidx.tv", name = "tv-material", version.ref = "tvCompose" }
+androidx-tv-foundation = { group = "androidx.tv", name = "tv-foundation", version = "1.0.0-alpha12" }
+androidx-tv-material = { group = "androidx.tv", name = "tv-material", version = "1.0.0" }
 
 openpass-core = { group = "com.myopenpass.sdk", name = "openpass-android-sdk", version.ref = "openpass" }
 openpass-tv = { group = "com.myopenpass.sdk", name = "openpass-android-sdk-tv", version.ref = "openpass" }

--- a/android/tv-device-auth-grant/gradle/libs.versions.toml
+++ b/android/tv-device-auth-grant/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ coreKtx = "1.15.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.0"
 composeBom = "2025.01.01"
-tvCompose = "1.0.0-alpha10"
 openpass = "2.8.2"
 
 [libraries]
@@ -18,8 +17,8 @@ androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-tv-foundation = { group = "androidx.tv", name = "tv-foundation", version.ref = "tvCompose" }
-androidx-tv-material = { group = "androidx.tv", name = "tv-material", version.ref = "tvCompose" }
+androidx-tv-foundation = { group = "androidx.tv", name = "tv-foundation", version = "1.0.0-alpha12" }
+androidx-tv-material = { group = "androidx.tv", name = "tv-material", version = "1.0.0" }
 
 zxing-core = { group = "com.google.zxing", name = "core", version = "3.5.3" }
 


### PR DESCRIPTION
This PR fixes an issue where we tried to enforce the same version for Compose/TV/Foundation vs Compose/TV/Material. This shouldn't be the case, and is causing Renovate to fail to be able to independently update them.