### PR TITLE
Pin 3rd party dependencies in Dockerfile and Github Action Workflows

### DIFF
--- a/.github/workflows/build-and-release-dev.yml
+++ b/.github/workflows/build-and-release-dev.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
    
@@ -80,10 +80,10 @@ jobs:
       group: "deploy-dev-group"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Checkout kube-system-resources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: openpass-sso/kube-system-resources
         token: ${{ secrets.GH_ORG_KUBE_SYSTEM_RESOURCES_PAT }}

--- a/.github/workflows/build-and-release-dev.yml
+++ b/.github/workflows/build-and-release-dev.yml
@@ -7,12 +7,16 @@ on:
 env:
   PIANO_ECR_REPOSITORY: openpass-sample-site-piano
 
+permissions:
+  contents: read
+
 jobs:
 
   generate-tag-name:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag_container.outputs.tag }}
+
     steps:
       - name: Generate container tag
         id: tag_container
@@ -20,10 +24,17 @@ jobs:
         run: |
           # https://stackoverflow.com/a/58035262/19888675
           # $GITHUB_HEAD_REF on PR, and $GITHUB_REF on main push
-          branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          tag="${branch_name:0:30}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
+          branch_name=${GH_HEAD_REF:-${GH_REF#refs/heads/}}
+          tag="${branch_name:0:30}-${GH_SHA}-${GH_RUN_ID}-${GH_RUN_NUMBER}-${GH_RUN_ATTEMPT}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo “Tag: $tag”
+          echo "Tag: $tag"
+        env:
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_NUMBER: ${{ github.run_number }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
 
   build-piano:
     needs: generate-tag-name
@@ -34,26 +45,29 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
    
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         role-to-assume: ${{ secrets.ECR_PUSH_ROLE_ARN_DEV }}
         aws-region: us-east-1
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       working-directory: ./piano-io
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        TAG_NAME: ${{needs.generate-tag-name.outputs.tag}}
       run: |
-        docker build -t $ECR_REGISTRY/$PIANO_ECR_REPOSITORY:${{needs.generate-tag-name.outputs.tag}} .
-        docker push $ECR_REGISTRY/$PIANO_ECR_REPOSITORY:${{needs.generate-tag-name.outputs.tag}}
-        echo "Pushed image to $ECR_REGISTRY/$PIANO_ECR_REPOSITORY:${{needs.generate-tag-name.outputs.tag}}"
+        docker build -t "${ECR_REGISTRY}/${PIANO_ECR_REPOSITORY}:${TAG_NAME}" .
+        docker push "${ECR_REGISTRY}/${PIANO_ECR_REPOSITORY}:${TAG_NAME}"
+        echo "Pushed image to ${ECR_REGISTRY}/${PIANO_ECR_REPOSITORY}:${TAG_NAME}"
 
   deploy-piano-dev:
     needs: [generate-tag-name, build-piano]
@@ -64,6 +78,7 @@ jobs:
       contents: read
     concurrency:
       group: "deploy-dev-group"
+
     steps:
     - uses: actions/checkout@v4
     
@@ -80,15 +95,14 @@ jobs:
 
         git config user.name github_build_script
         git config user.email github_build_script@thetradedesk.com
-   
-        # download yq
-        wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -O /usr/bin/yq && chmod +x /usr/bin/yq
     
         # Updating production image tag
-        yq -i ".ttd-generic-deployment.image.tag = \"${{needs.generate-tag-name.outputs.tag}}\"" environments/dev/sample-site-piano/values.yaml
+        yq -i ".ttd-generic-deployment.image.tag = \"${TAG_NAME}\"" environments/dev/sample-site-piano/values.yaml
     
         # Commit changes
         git add environments/dev/sample-site-piano/values.yaml
-        git commit -m "Updating dev sample-site-piano image tag to ${{needs.generate-tag-name.outputs.tag}}"
+        git commit -m "Updating dev sample-site-piano image tag to ${TAG_NAME}"
     
         git push
+      env:
+        TAG_NAME: ${{needs.generate-tag-name.outputs.tag}}

--- a/.github/workflows/build-and-release-main.yml
+++ b/.github/workflows/build-and-release-main.yml
@@ -49,7 +49,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     
@@ -85,10 +85,10 @@ jobs:
       group: "deploy-dev-group"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Checkout kube-system-resources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: openpass-sso/kube-system-resources
         token: ${{ secrets.GH_ORG_KUBE_SYSTEM_RESOURCES_PAT }}
@@ -124,10 +124,10 @@ jobs:
       group: "deploy-stg-group"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Checkout kube-system-resources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: openpass-sso/kube-system-resources
         token: ${{ secrets.GH_ORG_KUBE_SYSTEM_RESOURCES_PAT }}
@@ -162,10 +162,10 @@ jobs:
       group: "deploy-prd-group"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Checkout kube-system-resources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: openpass-sso/kube-system-resources
         token: ${{ secrets.GH_ORG_KUBE_SYSTEM_RESOURCES_PAT }}

--- a/.github/workflows/build-and-release-main.yml
+++ b/.github/workflows/build-and-release-main.yml
@@ -10,12 +10,18 @@ on:
 env:
   PIANO_ECR_REPOSITORY: openpass-sample-site-piano
 
+permissions:
+  contents: read
+
 jobs:
 
   generate-tag-name:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.tag_container.outputs.tag }}
+
     steps:
       - name: Generate container tag
         id: tag_container
@@ -23,10 +29,17 @@ jobs:
         run: |
           # https://stackoverflow.com/a/58035262/19888675
           # $GITHUB_HEAD_REF on PR, and $GITHUB_REF on main push
-          branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          tag="${branch_name:0:30}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
+          branch_name=${GH_HEAD_REF:-${GH_REF#refs/heads/}}
+          tag="${branch_name:0:30}-${GH_SHA}-${GH_RUN_ID}-${GH_RUN_NUMBER}-${GH_RUN_ATTEMPT}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo “Tag: $tag”
+          echo "Tag: $tag"
+        env:
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_NUMBER: ${{ github.run_number }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
 
   build-piano:
     needs: generate-tag-name
@@ -37,26 +50,29 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         role-to-assume: ${{ secrets.ECR_PUSH_ROLE_ARN_DEV }}
         aws-region: us-east-1
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       working-directory: ./piano-io
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        TAG_NAME: ${{needs.generate-tag-name.outputs.tag}}
       run: |
-        docker build -t $ECR_REGISTRY/$PIANO_ECR_REPOSITORY:${{needs.generate-tag-name.outputs.tag}} .
-        docker push $ECR_REGISTRY/$PIANO_ECR_REPOSITORY:${{needs.generate-tag-name.outputs.tag}}
-        echo "Pushed image to $ECR_REGISTRY/$PIANO_ECR_REPOSITORY:${{needs.generate-tag-name.outputs.tag}}"
+        docker build -t "${ECR_REGISTRY}/${PIANO_ECR_REPOSITORY}:${TAG_NAME}" .
+        docker push "${ECR_REGISTRY}/${PIANO_ECR_REPOSITORY}:${TAG_NAME}"
+        echo "Pushed image to ${ECR_REGISTRY}/${PIANO_ECR_REPOSITORY}:${TAG_NAME}"
 
   deploy-piano-dev:
     needs: [generate-tag-name, build-piano]
@@ -67,6 +83,7 @@ jobs:
       contents: read
     concurrency:
       group: "deploy-dev-group"
+
     steps:
     - uses: actions/checkout@v4
     
@@ -83,18 +100,17 @@ jobs:
 
         git config user.name github_build_script
         git config user.email github_build_script@thetradedesk.com
-   
-        # download yq
-        wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -O /usr/bin/yq && chmod +x /usr/bin/yq
     
         # Updating production image tag
-        yq -i ".ttd-generic-deployment.image.tag = \"${{needs.generate-tag-name.outputs.tag}}\"" environments/dev/sample-site-piano/values.yaml
+        yq -i ".ttd-generic-deployment.image.tag = \"${TAG_NAME}\"" environments/dev/sample-site-piano/values.yaml
     
         # Commit changes
         git add environments/dev/sample-site-piano/values.yaml
-        git commit -m "Updating dev sample-site-piano image tag to ${{needs.generate-tag-name.outputs.tag}}"
+        git commit -m "Updating dev sample-site-piano image tag to ${TAG_NAME}"
     
         git push
+      env:
+        TAG_NAME: ${{needs.generate-tag-name.outputs.tag}}
 
 
   deploy-piano-stg:
@@ -102,10 +118,11 @@ jobs:
     environment: stg
     runs-on: ubuntu-latest
     permissions:
-        id-token: write
-        contents: read
+      id-token: write
+      contents: read
     concurrency:
-        group: "deploy-stg-group"
+      group: "deploy-stg-group"
+
     steps:
     - uses: actions/checkout@v4
 
@@ -123,17 +140,16 @@ jobs:
         git config user.name github_build_script
         git config user.email github_build_script@thetradedesk.com
 
-        # download yq
-        wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -O /usr/bin/yq && chmod +x /usr/bin/yq
-
         # Updating production image tag
-        yq -i ".ttd-generic-deployment.image.tag = \"${{needs.generate-tag-name.outputs.tag}}\"" environments/stg/sample-site-piano/values.yaml
+        yq -i ".ttd-generic-deployment.image.tag = \"${TAG_NAME}\"" environments/stg/sample-site-piano/values.yaml
 
         # Commit changes
         git add environments/stg/sample-site-piano/values.yaml
-        git commit -m "Updating stg sample-site-piano image tag to ${{needs.generate-tag-name.outputs.tag}}"
+        git commit -m "Updating stg sample-site-piano image tag to ${TAG_NAME}"
 
         git push
+      env:
+        TAG_NAME: ${{needs.generate-tag-name.outputs.tag}}
 
   deploy-piano-prd:
     needs: [generate-tag-name, build-piano, deploy-piano-stg]
@@ -144,6 +160,7 @@ jobs:
       contents: read
     concurrency:
       group: "deploy-prd-group"
+
     steps:
     - uses: actions/checkout@v4
 
@@ -161,14 +178,13 @@ jobs:
         git config user.name github_build_script
         git config user.email github_build_script@thetradedesk.com
 
-        # download yq
-        wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -O /usr/bin/yq && chmod +x /usr/bin/yq
-
         # Updating production image tag
-        yq -i ".ttd-generic-deployment.image.tag = \"${{needs.generate-tag-name.outputs.tag}}\"" environments/prd/sample-site-piano/values.yaml
+        yq -i ".ttd-generic-deployment.image.tag = \"${TAG_NAME}\"" environments/prd/sample-site-piano/values.yaml
 
         # Commit changes
         git add environments/prd/sample-site-piano/values.yaml
-        git commit -m "Updating prd sample-site-piano image tag to ${{needs.generate-tag-name.outputs.tag}}"
+        git commit -m "Updating prd sample-site-piano image tag to ${TAG_NAME}"
 
         git push
+      env:
+        TAG_NAME: ${{needs.generate-tag-name.outputs.tag}}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -23,18 +23,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
       - name: Build with Gradle (Mobile)
         working-directory: android/mobile

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -13,6 +13,9 @@ on:
   # This allows us to manually run this job
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   kotlin-code-checks:
@@ -21,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -29,7 +34,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
 
       - name: Build with Gradle (Mobile)
         working-directory: android/mobile

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -13,6 +13,9 @@ on:
   # This allows us to manually run this job
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   swift-code-checks:
@@ -21,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Select Xcode 15.3
         run: sudo xcode-select -s /Applications/Xcode_15.3.app

--- a/.github/workflows/build-on-pull-request-to-main.yml
+++ b/.github/workflows/build-on-pull-request-to-main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
    

--- a/.github/workflows/build-on-pull-request-to-main.yml
+++ b/.github/workflows/build-on-pull-request-to-main.yml
@@ -1,8 +1,11 @@
-name: Build + release PR branch to dev
+name: Build PR branch
 
 on:
   pull_request:
     branches: [ main ]
+
+permissions:
+  contents: read
 
 jobs:
 
@@ -11,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
    
     - name: Test Docker build
       id: build-image

--- a/.github/workflows/build-roku.yml
+++ b/.github/workflows/build-roku.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/build-roku.yml
+++ b/.github/workflows/build-roku.yml
@@ -13,6 +13,9 @@ on:
   # This allows us to manually run this job
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   brightscript-code-checks:
     name: Code Tests
@@ -21,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          working-directory: roku
+          persist-credentials: false
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/piano-io/Dockerfile
+++ b/piano-io/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19.4@sha256:2c071012e93673d595e1399564c4a48a70a5c0a0acd7db8211d5e6f6316b431a
+FROM node:20.19.5@sha256:abcf9c98af22ea2c5d33435143d9d8a5f6f191e1e1938a7650fc8b78c382b5a9
 WORKDIR /app
 COPY package*.json ./
 RUN npm install

--- a/piano-io/Dockerfile
+++ b/piano-io/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:20.19.4@sha256:2c071012e93673d595e1399564c4a48a70a5c0a0acd7db8211d5e6f6316b431a
 WORKDIR /app
 COPY package*.json ./
 RUN npm install

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,37 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":configMigration",
+    "docker:pinDigests"
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": [
+      "matchDatasources": [
         "*"
       ],
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Pin digests for GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Override to keep official GitHub Actions unpinned",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": false,
+      "matchPackageNames": [
+        "/^actions//"
+      ]
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
## JIRA Ticket

https://thetradedesk.atlassian.net/browse/OPENPASS-2786

## What does this PR solve?

Locks Dockerfile and GitHub Actions dependencies with SHA digest pinning to achieve reproducible builds. Also:
- Explicitly set job permissions instead of implicit defaults.
- Remove persisted credentials where they are not needed (when no subsequent git operations are performed).
- Set input to environment variables to avoid command injections.
- Remove broken wget yq command because GitHub runners now have it out of the box.
- Add renovate.json config to pin/update third-party GitHub Actions.