### PR TITLE
OPENPASS-2515: Use GitHub App auth instead of PAT for kube-system-resources

### DIFF
--- a/.github/actions/checkout-kube-system-resources/action.yml
+++ b/.github/actions/checkout-kube-system-resources/action.yml
@@ -1,0 +1,30 @@
+name: Checkout kube-system-resources
+description: Authenticates as the OpenPass Release Bot GitHub App and checks out openpass-sso/kube-system-resources
+
+inputs:
+  client-id:
+    description: OpenPass Release Bot GitHub App client ID
+    required: true
+  private-key:
+    description: OpenPass Release Bot GitHub App private key
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Authenticate as OpenPass Release Bot GitHub App
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.client-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: openpass-sso
+        repositories: kube-system-resources
+        permission-contents: write
+
+    - name: Checkout kube-system-resources
+      uses: actions/checkout@v6
+      with:
+        repository: openpass-sso/kube-system-resources
+        token: ${{ steps.app-token.outputs.token }}
+        path: kube-system-resources

--- a/.github/workflows/build-and-release-dev.yml
+++ b/.github/workflows/build-and-release-dev.yml
@@ -83,11 +83,10 @@ jobs:
     - uses: actions/checkout@v5
     
     - name: Checkout kube-system-resources
-      uses: actions/checkout@v5
+      uses: ./.github/actions/checkout-kube-system-resources
       with:
-        repository: openpass-sso/kube-system-resources
-        token: ${{ secrets.GH_ORG_KUBE_SYSTEM_RESOURCES_PAT }}
-        path: kube-system-resources
+        client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+        private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
     
     - name: Set dev Docker image tag
       run: |

--- a/.github/workflows/build-and-release-main.yml
+++ b/.github/workflows/build-and-release-main.yml
@@ -88,12 +88,11 @@ jobs:
     - uses: actions/checkout@v5
     
     - name: Checkout kube-system-resources
-      uses: actions/checkout@v5
+      uses: ./.github/actions/checkout-kube-system-resources
       with:
-        repository: openpass-sso/kube-system-resources
-        token: ${{ secrets.GH_ORG_KUBE_SYSTEM_RESOURCES_PAT }}
-        path: kube-system-resources
-    
+        client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+        private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
     - name: Set dev Docker image tag
       run: |
         cd kube-system-resources
@@ -127,11 +126,10 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Checkout kube-system-resources
-      uses: actions/checkout@v5
+      uses: ./.github/actions/checkout-kube-system-resources
       with:
-        repository: openpass-sso/kube-system-resources
-        token: ${{ secrets.GH_ORG_KUBE_SYSTEM_RESOURCES_PAT }}
-        path: kube-system-resources
+        client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+        private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
     - name: Set stg Docker image tag
       run: |
@@ -165,11 +163,10 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Checkout kube-system-resources
-      uses: actions/checkout@v5
+      uses: ./.github/actions/checkout-kube-system-resources
       with:
-        repository: openpass-sso/kube-system-resources
-        token: ${{ secrets.GH_ORG_KUBE_SYSTEM_RESOURCES_PAT }}
-        path: kube-system-resources
+        client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+        private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
     - name: Set prd Docker image tag
       run: |


### PR DESCRIPTION
## Summary

Replaces the long-lived `GH_ORG_KUBE_SYSTEM_RESOURCES_PAT` secret with a short-lived token minted from the "OpenPass Release Bot" GitHub App when checking out `openpass-sso/kube-system-resources` during dev/stg/prd release workflows.

- Adds a reusable composite action, `.github/actions/checkout-kube-system-resources`, which authenticates as the OpenPass Release Bot GitHub App (via `actions/create-github-app-token@v3`, scoped to `contents:write` on `kube-system-resources` only) and then checks out the repo with the resulting token.
- Updates the 4 matching checkout steps (1 in `build-and-release-dev.yml`, 3 in `build-and-release-main.yml` — dev/stg/prd deploy jobs) to use the new composite action instead of `actions/checkout` + the PAT secret.
- No other checkout steps (e.g. checking out this repo itself) were touched.

This mirrors the identical migration already merged in `openpass-frontend` (and `openpass-api`) for the same ticket, OPENPASS-2515. The org-level `RELEASE_BOT_CLIENT_ID` variable and `RELEASE_BOT_PRIVATE_KEY` secret are already configured org-wide per that prior work, so no additional setup should be required here.

## Test plan

- [ ] YAML validated to parse correctly for all three changed/added files (done locally via Ruby's YAML parser, since PyYAML/actionlint weren't available in this environment)
- [ ] Confirmed `grep -r GH_ORG_KUBE_SYSTEM_RESOURCES_PAT .github/` returns no results after this change
- [ ] **Reviewer: please confirm the org-level `RELEASE_BOT_CLIENT_ID` variable and `RELEASE_BOT_PRIVATE_KEY` secret are actually accessible to this repo (`openpass-sample-sites`) before merging** — this could not be verified with the available token/permissions from this session
- [ ] Manually trigger (or wait for) the dev release workflow after merge to confirm the new composite action successfully authenticates and checks out `kube-system-resources`

🤖 Generated with [Claude Code](https://claude.com/claude-code)